### PR TITLE
Adding RHEL 8.x and Ubuntu 20.04 support

### DIFF
--- a/NvidiaGPU/resources.json
+++ b/NvidiaGPU/resources.json
@@ -174,7 +174,7 @@
       "Name" : "Linux",
       "Version" : [
         {
-          "Name" : "Ubuntu",
+          "Name" : "Ubuntu16.x",
           "Driver" : [
             {
               "Type" : "CUDA",
@@ -182,16 +182,19 @@
                 {
                   "Num" : "10.0.130",
                   "DirLink" : "http://download.microsoft.com/download/9/3/5/9356AEC3-D562-4E16-BF7A-4369980CB0D5/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb",
-                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874271"
+                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874271",
+                  "InstallMethod" : 0
                 },
                 {
                   "Num" : "9.2.88",
-                  "FwLink" : "http://download.microsoft.com/download/F/F/A/FFAC979D-AD9C-4684-A6CE-C92BB9372A3B/cuda-repo-ubuntu1604_9.2.88-1_amd64.deb"
+                  "FwLink" : "http://download.microsoft.com/download/F/F/A/FFAC979D-AD9C-4684-A6CE-C92BB9372A3B/cuda-repo-ubuntu1604_9.2.88-1_amd64.deb",
+                  "InstallMethod" : 0
                 },
                 {
                   "Num" : "9.1.85",
                   "DirLink" : "http://download.microsoft.com/download/F/F/A/FFAC979D-AD9C-4684-A6CE-C92BB9372A3B/cuda-repo-ubuntu1604_9.1.85-1_amd64.deb",
-                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874831"
+                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874831",
+                  "InstallMethod" : 0
                 }
               ]
             },
@@ -253,7 +256,7 @@
           ]
         },
         {
-          "Name" : "RHEL/CentOS",
+          "Name" : "RHEL/CentOS7.x",
           "Driver" : [
             {
               "Type" : "CUDA",
@@ -261,16 +264,22 @@
                 {
                   "Num" : "10.0.130",
                   "DirLink" : "http://download.microsoft.com/download/9/3/5/9356AEC3-D562-4E16-BF7A-4369980CB0D5/cuda-repo-rhel7-10.0.130-1.x86_64.rpm",
-                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874273"
+                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874273",
+                  "DKMSUrl" : "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
+                  "InstallMethod" : 0
                 },
                 {
                   "Num" : "9.2.88",
-                  "FwLink" : "http://download.microsoft.com/download/F/F/A/FFAC979D-AD9C-4684-A6CE-C92BB9372A3B/cuda-repo-rhel7-9.2.88-1.x86_64.rpm"
+                  "FwLink" : "http://download.microsoft.com/download/F/F/A/FFAC979D-AD9C-4684-A6CE-C92BB9372A3B/cuda-repo-rhel7-9.2.88-1.x86_64.rpm",
+                  "DKMSUrl" : "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
+                  "InstallMethod" : 0
                 },
                 {
                   "Num" : "9.1.85",
                   "DirLink" : "http://download.microsoft.com/download/F/F/A/FFAC979D-AD9C-4684-A6CE-C92BB9372A3B/cuda-repo-rhel7-9.1.85-1.x86_64.rpm",
-                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874833"
+                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874833",
+                  "DKMSUrl" : "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
+                  "InstallMethod" : 0
                 }
               ]
             },
@@ -337,6 +346,243 @@
             "LatestKernel" : "3.10.0-1062.9.1.el7",
             "FwLink" : "https://aka.ms/lis"
           }
+        },
+        {
+          "Name" : "RHEL/CentOS8.x",
+          "Driver" : [
+            {
+              "Type" : "CUDA",
+              "Version" : [
+                {
+                  "Num" : "11.1",
+                  "RepoUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo",
+                  "DKMSUrl" : "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
+                  "InstallMethod" : 2
+                },
+                {
+                  "Num" : "11.0",
+                  "RepoUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo",
+                  "DKMSUrl" : "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
+                  "InstallMethod" : 2
+                }
+              ]
+            },
+            {
+              "Type" : "GRID",
+              "Version" : [
+                {
+                  "Num": "450.80",
+                  "DirLink": "https://download.microsoft.com/download/6/1/d/61dad7f0-7be6-48b5-b297-bd46e44a1f14/NVIDIA-Linux-x86_64-450.80.02-grid-azure.run",
+                  "FwLink": "https://go.microsoft.com/fwlink/?linkid=874272"
+                },
+                {
+                  "Num": "450.51",
+                  "FwLink": "https://download.microsoft.com/download/d/d/9/dd97a245-d277-4f43-915e-8d38b01334fb/NVIDIA-Linux-x86_64-450.51.05-grid-azure.run"
+                },
+                {
+                  "Num" : "440.56",
+                  "FwLink" : "https://download.microsoft.com/download/3/0/8/3084787d-078d-4a3d-b3e8-7394c6a1e2cd/NVIDIA-Linux-x86_64-440.56-grid-azure.run"
+                },
+                {
+                  "Num" : "440.43",
+                  "FwLink" : "https://download.microsoft.com/download/b/9/5/b95127da-6d8f-4dea-8d7d-827be40bb2b7/NVIDIA-Linux-x86_64-440.43-grid.run"
+                },
+                {
+                  "Num" : "430.46",
+                  "FwLink" : "https://download.microsoft.com/download/1/a/5/1a537cae-5b52-4348-acd2-2f210fc412b0/NVIDIA-Linux-x86_64-430.46-grid.run"
+                },
+                {
+                  "Num" : "430.30",
+                  "FwLink" : "http://download.microsoft.com/download/B/0/D/B0DD6405-CA50-4B99-A908-6D32C1B6836A/NVIDIA-Linux-x86_64-430.30-grid.run"
+                },
+                {
+                  "Num" : "418.70",
+                  "FwLink" : "http://download.microsoft.com/download/D/7/B/D7BC68DD-2BF3-4CBD-A6D3-AA7F68C22FD0/NVIDIA-Linux-x86_64-418.70-grid.run"
+                },
+                {
+                  "Num" : "410.92",
+                  "FwLink" : "http://download.microsoft.com/download/8/5/D/85DC7798-B9F7-4BB9-84E8-B3350D7B52F7/NVIDIA-Linux-x86_64-410.92-grid.run"
+                },
+                {
+                  "Num" : "410.71",
+                  "FwLink" : "http://download.microsoft.com/download/8/5/D/85DC7798-B9F7-4BB9-84E8-B3350D7B52F7/NVIDIA-Linux-x86_64-410.71-grid.run"
+                },
+                {
+                  "Num" : "390.75",
+                  "FwLink" : "http://download.microsoft.com/download/C/C/A/CCA1A402-D4EC-4260-BAD1-3AA1B004882A/NVIDIA-Linux-x86_64-390.75-grid.run"
+                },
+                {
+                  "Num" : "390.57",
+                  "FwLink" : "http://download.microsoft.com/download/6/0/4/6041F2BB-8194-4DB9-BA22-CF1898B9CB70/NVIDIA-Linux-x86_64-grid.run"
+                },
+                {
+                  "Num" : "390.42",
+                  "DirLink" : "http://download.microsoft.com/download/3/8/2/382E8D8A-7620-4F89-B772-A84D97524F7E/NVIDIA-Linux-x86_64-grid.run",
+                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874834"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Name" : "Ubuntu18.x",
+          "Driver" : [
+            {
+              "Type" : "CUDA",
+              "Version" : [
+                {
+                  "Num" : "11.1",
+                  "RepoUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/",
+                  "PinUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin",
+                  "InstallMethod" : 1
+                },
+                {
+                  "Num" : "11.0",
+                  "RepoUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/",
+                  "PinUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin",
+                  "InstallMethod" : 1
+                },
+                {
+                  "Num" : "10.0.130",
+                  "DirLink" : "http://download.microsoft.com/download/9/3/5/9356AEC3-D562-4E16-BF7A-4369980CB0D5/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb",
+                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874271",
+                  "InstallMethod" : 0
+                }
+              ]
+            },
+            {
+              "Type" : "GRID",
+              "Version" : [
+                {
+                  "Num": "450.80",
+                  "DirLink": "https://download.microsoft.com/download/6/1/d/61dad7f0-7be6-48b5-b297-bd46e44a1f14/NVIDIA-Linux-x86_64-450.80.02-grid-azure.run",
+                  "FwLink": "https://go.microsoft.com/fwlink/?linkid=874272"
+                },
+                {
+                  "Num": "450.51",
+                  "FwLink": "https://download.microsoft.com/download/d/d/9/dd97a245-d277-4f43-915e-8d38b01334fb/NVIDIA-Linux-x86_64-450.51.05-grid-azure.run"
+                },
+                {
+                  "Num" : "440.56",
+                  "FwLink" : "https://download.microsoft.com/download/3/0/8/3084787d-078d-4a3d-b3e8-7394c6a1e2cd/NVIDIA-Linux-x86_64-440.56-grid-azure.run"
+                },
+                {
+                  "Num" : "440.43",
+                  "FwLink" : "https://download.microsoft.com/download/b/9/5/b95127da-6d8f-4dea-8d7d-827be40bb2b7/NVIDIA-Linux-x86_64-440.43-grid.run"
+                },
+                {
+                  "Num" : "430.46",
+                  "FwLink" : "https://download.microsoft.com/download/1/a/5/1a537cae-5b52-4348-acd2-2f210fc412b0/NVIDIA-Linux-x86_64-430.46-grid.run"
+                },
+                {
+                  "Num" : "430.30",
+                  "FwLink" : "http://download.microsoft.com/download/B/0/D/B0DD6405-CA50-4B99-A908-6D32C1B6836A/NVIDIA-Linux-x86_64-430.30-grid.run"
+                },
+                {
+                  "Num" : "418.70",
+                  "FwLink" : "http://download.microsoft.com/download/D/7/B/D7BC68DD-2BF3-4CBD-A6D3-AA7F68C22FD0/NVIDIA-Linux-x86_64-418.70-grid.run"
+                },
+                {
+                  "Num" : "410.92",
+                  "FwLink" : "http://download.microsoft.com/download/8/5/D/85DC7798-B9F7-4BB9-84E8-B3350D7B52F7/NVIDIA-Linux-x86_64-410.92-grid.run"
+                },
+                {
+                  "Num" : "410.71",
+                  "FwLink" : "http://download.microsoft.com/download/8/5/D/85DC7798-B9F7-4BB9-84E8-B3350D7B52F7/NVIDIA-Linux-x86_64-410.71-grid.run"
+                },
+                {
+                  "Num" : "390.75",
+                  "FwLink" : "http://download.microsoft.com/download/C/C/A/CCA1A402-D4EC-4260-BAD1-3AA1B004882A/NVIDIA-Linux-x86_64-390.75-grid.run"
+                },
+                {
+                  "Num" : "390.57",
+                  "FwLink" : "http://download.microsoft.com/download/6/0/4/6041F2BB-8194-4DB9-BA22-CF1898B9CB70/NVIDIA-Linux-x86_64-grid.run"
+                },
+                {
+                  "Num" : "390.42",
+                  "DirLink" : "http://download.microsoft.com/download/3/8/2/382E8D8A-7620-4F89-B772-A84D97524F7E/NVIDIA-Linux-x86_64-grid.run",
+                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874834"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Name" : "Ubuntu20.x",
+          "Driver" : [
+            {
+              "Type" : "CUDA",
+              "Version" : [
+                {
+                  "Num" : "11.1",
+                  "RepoUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/",
+                  "PinUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin",
+                  "InstallMethod" : 1
+                },
+                {
+                  "Num" : "11.0",
+                  "RepoUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/",
+                  "PinUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin",
+                  "InstallMethod" : 1
+                }
+              ]
+            },
+            {
+              "Type" : "GRID",
+              "Version" : [
+                {
+                  "Num": "450.80",
+                  "DirLink": "https://download.microsoft.com/download/6/1/d/61dad7f0-7be6-48b5-b297-bd46e44a1f14/NVIDIA-Linux-x86_64-450.80.02-grid-azure.run",
+                  "FwLink": "https://go.microsoft.com/fwlink/?linkid=874272"
+                },
+                {
+                  "Num": "450.51",
+                  "FwLink": "https://download.microsoft.com/download/d/d/9/dd97a245-d277-4f43-915e-8d38b01334fb/NVIDIA-Linux-x86_64-450.51.05-grid-azure.run"
+                },
+                {
+                  "Num" : "440.56",
+                  "FwLink" : "https://download.microsoft.com/download/3/0/8/3084787d-078d-4a3d-b3e8-7394c6a1e2cd/NVIDIA-Linux-x86_64-440.56-grid-azure.run"
+                },
+                {
+                  "Num" : "440.43",
+                  "FwLink" : "https://download.microsoft.com/download/b/9/5/b95127da-6d8f-4dea-8d7d-827be40bb2b7/NVIDIA-Linux-x86_64-440.43-grid.run"
+                },
+                {
+                  "Num" : "430.46",
+                  "FwLink" : "https://download.microsoft.com/download/1/a/5/1a537cae-5b52-4348-acd2-2f210fc412b0/NVIDIA-Linux-x86_64-430.46-grid.run"
+                },
+                {
+                  "Num" : "430.30",
+                  "FwLink" : "http://download.microsoft.com/download/B/0/D/B0DD6405-CA50-4B99-A908-6D32C1B6836A/NVIDIA-Linux-x86_64-430.30-grid.run"
+                },
+                {
+                  "Num" : "418.70",
+                  "FwLink" : "http://download.microsoft.com/download/D/7/B/D7BC68DD-2BF3-4CBD-A6D3-AA7F68C22FD0/NVIDIA-Linux-x86_64-418.70-grid.run"
+                },
+                {
+                  "Num" : "410.92",
+                  "FwLink" : "http://download.microsoft.com/download/8/5/D/85DC7798-B9F7-4BB9-84E8-B3350D7B52F7/NVIDIA-Linux-x86_64-410.92-grid.run"
+                },
+                {
+                  "Num" : "410.71",
+                  "FwLink" : "http://download.microsoft.com/download/8/5/D/85DC7798-B9F7-4BB9-84E8-B3350D7B52F7/NVIDIA-Linux-x86_64-410.71-grid.run"
+                },
+                {
+                  "Num" : "390.75",
+                  "FwLink" : "http://download.microsoft.com/download/C/C/A/CCA1A402-D4EC-4260-BAD1-3AA1B004882A/NVIDIA-Linux-x86_64-390.75-grid.run"
+                },
+                {
+                  "Num" : "390.57",
+                  "FwLink" : "http://download.microsoft.com/download/6/0/4/6041F2BB-8194-4DB9-BA22-CF1898B9CB70/NVIDIA-Linux-x86_64-grid.run"
+                },
+                {
+                  "Num" : "390.42",
+                  "DirLink" : "http://download.microsoft.com/download/3/8/2/382E8D8A-7620-4F89-B772-A84D97524F7E/NVIDIA-Linux-x86_64-grid.run",
+                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874834"
+                }
+              ]
+            }
+          ]
         }
       ],
       "PublicKey" : {


### PR DESCRIPTION
Adding Support for RHEL 8 and Ubuntu 20.04

The changes are back-compatible, i.e. the new additions will not affect existing supported OS.