### PR TITLE
Changing Pub Key URL to use https

### DIFF
--- a/NvidiaGPU/resources.json
+++ b/NvidiaGPU/resources.json
@@ -356,7 +356,7 @@
         }
       ],
       "PublicKey" : {
-        "FwLink" : "http://download.microsoft.com/download/F/F/A/FFAC979D-AD9C-4684-A6CE-C92BB9372A3B/7fa2af80.pub"
+        "FwLink" : "https://download.microsoft.com/download/F/F/A/FFAC979D-AD9C-4684-A6CE-C92BB9372A3B/7fa2af80.pub"
       }
     }
   ],


### PR DESCRIPTION
Changing PubKey URL to use HTTPS instead of HTTP.
Few customers wants to use secure URL, hence this would unblock them.