### PR TITLE
adding support for NCv1

### DIFF
--- a/NvidiaGPU/resources.json
+++ b/NvidiaGPU/resources.json
@@ -427,6 +427,23 @@
                   "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874834"
                 }
               ]
+            },
+            {
+              "Type" : "CUDA with last supported Nvidia driver",
+              "Version" : [
+                {
+                  "Comment" : "For NCv1 series / Tesla K80 GPUs",
+                  "SkuRegEx" : "(nc[0-9]+r?)$",
+                  "Num" : "10.0.130",
+                  "DirLink" : "https://download.microsoft.com/download/9/3/5/9356AEC3-D562-4E16-BF7A-4369980CB0D5/cuda-repo-rhel7-10.0.130-1.x86_64.rpm",
+                  "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874273",
+                  "DriverVersion" : "470.82.01",
+                  "DriverDirLink" : "https://download.microsoft.com/download/d/9/1/d9199489-e041-4019-a558-59fc58571a9f/nvidia-driver-local-repo-rhel7-470.82.01-1.0-1.x86_64.rpm",
+                  "DriverFwLink" : "https://go.microsoft.com/fwlink/?linkid=2180349",
+                  "DKMSUrl" : "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
+                  "InstallMethod" : 0
+                }
+              ]
             }
           ],
           "DKMS" : {
@@ -530,6 +547,20 @@
                   "Num" : "390.42",
                   "DirLink" : "https://download.microsoft.com/download/3/8/2/382E8D8A-7620-4F89-B772-A84D97524F7E/NVIDIA-Linux-x86_64-grid.run",
                   "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874834"
+                }
+              ]
+            },
+            {
+              "Type" : "CUDA with last supported Nvidia driver",
+              "Version" : [
+                {
+                  "Comment" : "For NCv1 series / Tesla K80 GPUs",
+                  "SkuRegEx" : "(nc[0-9]+r?)$",
+                  "Num" : "11.1",
+                  "RepoUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo",
+                  "DKMSUrl" : "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
+                  "DriverVersion" : "470",
+                  "InstallMethod" : 2
                 }
               ]
             }
@@ -636,6 +667,20 @@
                   "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874834"
                 }
               ]
+            },
+            {
+              "Type" : "CUDA with last supported Nvidia driver",
+              "Version" : [
+                {
+                  "Comment" : "For NCv1 series / Tesla K80 GPUs",
+                  "SkuRegEx" : "(nc[0-9]+r?)$",
+                  "Num" : "11.1",
+                  "RepoUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/",
+                  "PinUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin",
+                  "DriverVersion" : "470",
+                  "InstallMethod" : 1
+                }
+              ]
             }
           ]
         },
@@ -732,6 +777,20 @@
                   "Num" : "390.42",
                   "DirLink" : "https://download.microsoft.com/download/3/8/2/382E8D8A-7620-4F89-B772-A84D97524F7E/NVIDIA-Linux-x86_64-grid.run",
                   "FwLink" : "https://go.microsoft.com/fwlink/?linkid=874834"
+                }
+              ]
+            },
+            {
+              "Type" : "CUDA with last supported Nvidia driver",
+              "Version" : [
+                {
+                  "Comment" : "For NCv1 series / Tesla K80 GPUs",
+                  "SkuRegEx" : "(nc[0-9]+r?)$",
+                  "Num" : "11.1",
+                  "RepoUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/",
+                  "PinUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin",
+                  "DriverVersion" : "470",
+                  "InstallMethod" : 1
                 }
               ]
             }


### PR DESCRIPTION
Adding support for NCv1 series / Tesla K80 GPUs for Linux. 

- Adding new section within each Linux distro to handle deprecated driver support: includes CUDA toolkit with the last supported Nvidia Driver
- Each version section has the same properties as in the "CUDA" section for the respective Linux distro, along with additional properties:
  - a "Comment" property describing which VM series it applies to.
  - a "SkuRegEx" property that contains the regex that details which VM sizes it applies to.
  - a "DriverVersion" property that is the version of the Nvidia CUDA driver.
- Adding Nvidia CUDA driver 470.82.01 for RHEL 7
  - Has property "DriverDirLink" and "DriverFwLink" that contains the respective link to the driver package.