### PR TITLE
Update OFED for Linux and adding support for CX3Pro

### DIFF
--- a/InfiniBand/resources.json
+++ b/InfiniBand/resources.json
@@ -40,7 +40,7 @@
               ]
             },
             {
-              "Comment" : "Driver version is 5.0-1.0.0.0",
+              "Comment" : "Driver version is 5.5-1.0.3.2",
               "Name" : "Linux",
               "Distro" : [
                 {
@@ -48,15 +48,15 @@
                   "Version" : [
                     {
                       "Num" : "20.04",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-ubuntu20.04-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-ubuntu20.04-x86_64.tgz"
                     },
                     {
                       "Num" : "18.04",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-ubuntu18.04-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-ubuntu18.04-x86_64.tgz"
                     },
                     {
                       "Num" : "16.04",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-ubuntu16.04-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-ubuntu16.04-x86_64.tgz"
                     }
                   ]
                 },
@@ -65,31 +65,39 @@
                   "Version" : [
                     {
                       "Num" : "8.2",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel8.2-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel8.2-x86_64.tgz"
                     },
                     {
                       "Num" : "8.1",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel8.1-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel8.1-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "7.9",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.9-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "7.8",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.8-x86_64.tgz"
                     },
                     {
                       "Num" : "7.7",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel7.7-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.7-x86_64.tgz"
                     },
                     {
                       "Num" : "7.6",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel7.6-x86_64.tgz",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.6-x86_64.tgz",
                       "KernelDevelVer" : "3.10.0-957.27.2.el7.x86_64",
                       "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-957.27.2.el7.x86_64.rpm"
                     },
                     {
                       "Num" : "7.5",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel7.5-x86_64.tgz",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.5-x86_64.tgz",
                       "KernelDevelVer" : "3.10.0-862.11.6.el7.x86_64",
                       "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-862.11.6.el7.x86_64.rpm"
                     },
                     {
                       "Num" : "7.4",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel7.4-x86_64.tgz",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.4-x86_64.tgz",
                       "KernelDevelVer" : "3.10.0-693.21.1.el7.x86_64",
                       "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-693.21.1.el7.x86_64.rpm"
                     }
@@ -136,7 +144,7 @@
               ]
             },
             {
-              "Comment" : "Driver version is 5.0-1.0.0.0",
+              "Comment" : "Driver version is 5.5-1.0.3.2",
               "Name" : "Linux",
               "Distro" : [
                 {
@@ -144,15 +152,15 @@
                   "Version" : [
                     {
                       "Num" : "20.04",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-ubuntu20.04-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-ubuntu20.04-x86_64.tgz"
                     },
                     {
                       "Num" : "18.04",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-ubuntu18.04-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-ubuntu18.04-x86_64.tgz"
                     },
                     {
                       "Num" : "16.04",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-ubuntu16.04-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-ubuntu16.04-x86_64.tgz"
                     }
                   ]
                 },
@@ -161,31 +169,39 @@
                   "Version" : [
                     {
                       "Num" : "8.2",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel8.2-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel8.2-x86_64.tgz"
                     },
                     {
                       "Num" : "8.1",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel8.1-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel8.1-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "7.9",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.9-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "7.8",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.8-x86_64.tgz"
                     },
                     {
                       "Num" : "7.7",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel7.7-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.7-x86_64.tgz"
                     },
                     {
                       "Num" : "7.6",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel7.6-x86_64.tgz",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.6-x86_64.tgz",
                       "KernelDevelVer" : "3.10.0-957.27.2.el7.x86_64",
                       "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-957.27.2.el7.x86_64.rpm"
                     },
                     {
                       "Num" : "7.5",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel7.5-x86_64.tgz",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.5-x86_64.tgz",
                       "KernelDevelVer" : "3.10.0-862.11.6.el7.x86_64",
                       "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-862.11.6.el7.x86_64.rpm"
                     },
                     {
                       "Num" : "7.4",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.0-1.0.0.0/MLNX_OFED_LINUX-5.0-1.0.0.0-rhel7.4-x86_64.tgz",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_LINUX-5.5-1.0.3.2-rhel7.4-x86_64.tgz",
                       "KernelDevelVer" : "3.10.0-693.21.1.el7.x86_64",
                       "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-693.21.1.el7.x86_64.rpm"
                     }
@@ -199,7 +215,7 @@
           "Type" : "CX3-Pro",
           "OS" : [
             {
-              "Comment" : "Driver version is 5.65. Win 2019 and Win 10 are not supported yet.",
+              "Comment" : "Driver version is 5.65.",
               "Name" : "Windows",
               "Distro" : [
                 {
@@ -226,6 +242,72 @@
                     {
                       "Num" : "All",
                       "FwLink" : "https://download.microsoft.com/download/e/5/c/e5cb143e-f3d4-467b-b874-1aa7d5a7af7c/MLNX_VPI_WinOF-5_65_51000_All_win2019_x64.exe"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Comment" : "Driver version is 4.9-4.0.8.0",
+              "Name" : "Linux",
+              "Distro" : [
+                {
+                  "Name" : "Ubuntu",
+                  "Version" : [
+                    {
+                      "Num" : "20.04",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-ubuntu20.04-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "18.04",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-ubuntu18.04-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "16.04",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-ubuntu16.04-x86_64.tgz"
+                    }
+                  ]
+                },
+                {
+                  "Name" : "RHEL/CentOS",
+                  "Version" : [
+                    {
+                      "Num" : "8.2",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel8.2-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "8.1",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel8.1-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "7.9",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.9-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "7.8",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.8-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "7.7",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.7-x86_64.tgz"
+                    },
+                    {
+                      "Num" : "7.6",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.6-x86_64.tgz",
+                      "KernelDevelVer" : "3.10.0-957.27.2.el7.x86_64",
+                      "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-957.27.2.el7.x86_64.rpm"
+                    },
+                    {
+                      "Num" : "7.5",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.5-x86_64.tgz",
+                      "KernelDevelVer" : "3.10.0-862.11.6.el7.x86_64",
+                      "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-862.11.6.el7.x86_64.rpm"
+                    },
+                    {
+                      "Num" : "7.4",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.4-x86_64.tgz",
+                      "KernelDevelVer" : "3.10.0-693.21.1.el7.x86_64",
+                      "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-693.21.1.el7.x86_64.rpm"
                     }
                   ]
                 }

--- a/InfiniBand/resources.json
+++ b/InfiniBand/resources.json
@@ -248,7 +248,7 @@
               ]
             },
             {
-              "Comment" : "Driver version is 4.9-4.0.8.0",
+              "Comment" : "Driver version is 4.9-4.1.7.0",
               "Name" : "Linux",
               "Distro" : [
                 {
@@ -256,15 +256,15 @@
                   "Version" : [
                     {
                       "Num" : "20.04",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-ubuntu20.04-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-ubuntu20.04-x86_64.tgz"
                     },
                     {
                       "Num" : "18.04",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-ubuntu18.04-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-ubuntu18.04-x86_64.tgz"
                     },
                     {
                       "Num" : "16.04",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-ubuntu16.04-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-ubuntu16.04-x86_64.tgz"
                     }
                   ]
                 },
@@ -273,39 +273,39 @@
                   "Version" : [
                     {
                       "Num" : "8.2",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel8.2-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-rhel8.2-x86_64.tgz"
                     },
                     {
                       "Num" : "8.1",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel8.1-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-rhel8.1-x86_64.tgz"
                     },
                     {
                       "Num" : "7.9",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.9-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-rhel7.9-x86_64.tgz"
                     },
                     {
                       "Num" : "7.8",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.8-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-rhel7.8-x86_64.tgz"
                     },
                     {
                       "Num" : "7.7",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.7-x86_64.tgz"
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-rhel7.7-x86_64.tgz"
                     },
                     {
                       "Num" : "7.6",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.6-x86_64.tgz",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-rhel7.6-x86_64.tgz",
                       "KernelDevelVer" : "3.10.0-957.27.2.el7.x86_64",
                       "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-957.27.2.el7.x86_64.rpm"
                     },
                     {
                       "Num" : "7.5",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.5-x86_64.tgz",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-rhel7.5-x86_64.tgz",
                       "KernelDevelVer" : "3.10.0-862.11.6.el7.x86_64",
                       "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-862.11.6.el7.x86_64.rpm"
                     },
                     {
                       "Num" : "7.4",
-                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_LINUX-4.9-4.0.8.0-rhel7.4-x86_64.tgz",
+                      "FwLink" : "http://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_LINUX-4.9-4.1.7.0-rhel7.4-x86_64.tgz",
                       "KernelDevelVer" : "3.10.0-693.21.1.el7.x86_64",
                       "KernelDevelRPM" : "https://linuxsoft.cern.ch/cern/centos/7/updates/x86_64/Packages/kernel-devel-3.10.0-693.21.1.el7.x86_64.rpm"
                     }


### PR DESCRIPTION
- updating Linux IB OFED to version 5.5-1.0.3.2
- adding links for rhel/centos 7.8 and 7.9
- adding Linux section for CX3Pro with OFED version 4.9-4.1.7.0