### PR TITLE
Update pub key ubuntu

### DIFF
--- a/NvidiaGPU/resources.json
+++ b/NvidiaGPU/resources.json
@@ -861,7 +861,7 @@
         }
       ],
       "PublicKey" : {
-        "FwLink" : "https://download.microsoft.com/download/F/F/A/FFAC979D-AD9C-4684-A6CE-C92BB9372A3B/7fa2af80.pub"
+        "FwLink" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub"
       }
     }
   ],

--- a/NvidiaGPU/resources.json
+++ b/NvidiaGPU/resources.json
@@ -861,7 +861,7 @@
         }
       ],
       "PublicKey" : {
-        "FwLink" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub"
+        "FwLink" : "https://download.microsoft.com/download/f/4/7/f472d46c-1bc2-49dc-b43b-c803ce3e2f1d/3bf863cc.pub"
       }
     }
   ],


### PR DESCRIPTION
Nvidia has updated the signing keys, so updating the pubkey (for Ubuntu) to be able to install packages from CUDA repositories.