### PR TITLE
update ubuntu keyring

### DIFF
--- a/NvidiaGPU/resources.json
+++ b/NvidiaGPU/resources.json
@@ -982,7 +982,7 @@
       ],
       "PublicKey" : {
         "FwLink" : "https://download.microsoft.com/download/f/4/7/f472d46c-1bc2-49dc-b43b-c803ce3e2f1d/3bf863cc.pub",
-        "BaseUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/",
+        "BaseUrl" : "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/",
         "KeyRing" : "cuda-keyring_1.0-1_all.deb"
       }
     }


### PR DESCRIPTION
Updating Ubuntu Keyring to use Ubuntu 20.04 repo instead since 18.04 is EOL and the extension mainly supports 20.04. Will move keyring to be specific to each Ubuntu distro in the future.