### PR TITLE
NvidiaGPU: remove older vGPU Versions

### DIFF
--- a/NvidiaGPU/resources.json
+++ b/NvidiaGPU/resources.json
@@ -65,12 +65,6 @@
                   "SupportedOSVersions" : "Windows Server 2022, Windows 10 22H2, Windows 11 24H2, Windows 11 25H2"
                 },
                 {
-                  "Num": "595.97",
-                  "FwLink": "https://download.microsoft.com/download/169e58c8-9099-481e-a9a9-c237a189710c/595.97_grid_win10_win11_server2022_server2025_dch_64bit_international_azure_swl.exe",
-                  "vGPUVersion" :"20.0",
-                  "SupportedOSVersions" : "Windows Server 2022, Windows Server 2025, Windows 10 22H2, Windows 11 24H2"
-                },
-                {
                   "Num": "573.76",
                   "FwLink": "https://download.microsoft.com/download/dcf4d002-3a53-469d-91af-04bddf57a9d7/573.76_grid_win10_win11_server2019_server2022_server2025_dch_64bit_international_azure_swl.exe",
                   "vGPUVersion" :"18.5",
@@ -431,12 +425,6 @@
                   "Num": "595.91.07",
                   "FwLink": "https://download.microsoft.com/download/a7cb6d36-3bbc-43d6-9e88-e0842e6f9ab9/NVIDIA-Linux-x86_64-595.91.07-grid-azure.run",
                   "vGPUVersion" :"20.2",
-                  "SupportedOSVersions" : "Ubuntu 20.04 LTS, 22.04 LTS, 24.04 LTS, Red Hat Enterprise Linux 8.6, 8.8, 8.9"
-                },
-                {
-                  "Num": "595.58.03",
-                  "FwLink": "https://download.microsoft.com/download/51239696-ec04-4c02-a6b3-1d9c608fb57c/NVIDIA-Linux-x86_64-595.58.03-grid-azure.run",
-                  "vGPUVersion" :"20.0",
                   "SupportedOSVersions" : "Ubuntu 20.04 LTS, 22.04 LTS, 24.04 LTS, Red Hat Enterprise Linux 8.6, 8.8, 8.9"
                 },
                 {
@@ -834,12 +822,6 @@
                   "Num": "595.91.07",
                   "FwLink": "https://download.microsoft.com/download/a7cb6d36-3bbc-43d6-9e88-e0842e6f9ab9/NVIDIA-Linux-x86_64-595.91.07-grid-azure.run",
                   "vGPUVersion" :"20.2",
-                  "SupportedOSVersions" : "Ubuntu 20.04 LTS, 22.04 LTS, 24.04 LTS, Red Hat Enterprise Linux 8.6, 8.8, 8.9"
-                },
-                {
-                  "Num": "595.58.03",
-                  "FwLink": "https://download.microsoft.com/download/51239696-ec04-4c02-a6b3-1d9c608fb57c/NVIDIA-Linux-x86_64-595.58.03-grid-azure.run",
-                  "vGPUVersion" :"20.0",
                   "SupportedOSVersions" : "Ubuntu 20.04 LTS, 22.04 LTS, 24.04 LTS, Red Hat Enterprise Linux 8.6, 8.8, 8.9"
                 },
                 {
@@ -1271,12 +1253,6 @@
                   "Num": "595.91.07",
                   "FwLink": "https://download.microsoft.com/download/a7cb6d36-3bbc-43d6-9e88-e0842e6f9ab9/NVIDIA-Linux-x86_64-595.91.07-grid-azure.run",
                   "vGPUVersion" :"20.2",
-                  "SupportedOSVersions" : "Ubuntu 20.04 LTS, 22.04 LTS, 24.04 LTS, Red Hat Enterprise Linux 8.6, 8.8, 8.9"
-                },
-                {
-                  "Num": "595.58.03",
-                  "FwLink": "https://download.microsoft.com/download/51239696-ec04-4c02-a6b3-1d9c608fb57c/NVIDIA-Linux-x86_64-595.58.03-grid-azure.run",
-                  "vGPUVersion" :"20.0",
                   "SupportedOSVersions" : "Ubuntu 20.04 LTS, 22.04 LTS, 24.04 LTS, Red Hat Enterprise Linux 8.6, 8.8, 8.9"
                 },
                 {


### PR DESCRIPTION
## What changed
Removed the four `vGPUVersion "20.0"` driver entries from `NvidiaGPU/resources.json` (the Windows GRID section and the three identical Linux GRID sections).

## Why
The 20.0 vGPU driver entry is no longer needed/supported and should be removed from the resource catalog.

## Notes for reviewers
- Verified `NvidiaGPU/resources.json` is still valid JSON after the removal.
- Confirmed no other resource files (`Nvidia-GPU-Linux-Resources.json`, `Nvidia-GPU-Windows-Resources.json`, and their Sovereign counterparts) reference vGPUVersion 20.0.