### PR TITLE
Remove all repoLinks from AMD-GPU-Linux-Resources.json

### DIFF
--- a/AmdGPU/AMD-GPU-Linux-Resources.json
+++ b/AmdGPU/AMD-GPU-Linux-Resources.json
@@ -27,8 +27,7 @@
                                 "MinKernelsSupportedForOSVersion":{
                                     "Ubuntu 22.04" : ["6.8.*-azure"]
                                 },
-                                "MinimumDiskSpace" : "64 GB",
-                                "RepoLink" : "https://repo.radeon.com/amdgpu-install/latest/ubuntu/jammy/"
+                                "MinimumDiskSpace" : "64 GB"
                             },
                             {
                                 "SupportedOSVersions": [
@@ -37,8 +36,7 @@
                                 "MinKernelsSupportedForOSVersion":{
                                     "Ubuntu 24.04" : ["6.8.*-azure"]
                                 },
-                                "MinimumDiskSpace" : "64 GB",
-                                "RepoLink": "https://repo.radeon.com/amdgpu-install/latest/ubuntu/noble/"
+                                "MinimumDiskSpace" : "64 GB"
                             }
                         ]
                     }
@@ -65,7 +63,6 @@
                                     "Ubuntu 22.04" : ["6.8.*-azure"]
                                 },
                                 "MinimumDiskSpace" : "64 GB",
-                                "RepoLink" : "https://repo.radeon.com/amdgpu-install/6.4/ubuntu/jammy/",
                                 "DriverName": "amdgpu-install_6.4.60400-1_all.deb"
                             },
                             {
@@ -76,7 +73,6 @@
                                     "Ubuntu 24.04" : ["6.8.*-azure"]
                                 },
                                 "MinimumDiskSpace" : "64 GB",
-                                "RepoLink": "https://repo.radeon.com/amdgpu-install/6.4/ubuntu/noble/",
                                 "DriverName": "amdgpu-install_6.4.60400-1_all.deb"
                             }
                         ]
@@ -95,7 +91,6 @@
                                     "Ubuntu 22.04" : ["6.8.*-azure"]
                                 },
                                 "MinimumDiskSpace" : "64 GB",
-                                "RepoLink" : "https://repo.radeon.com/amdgpu-install/6.3.3/ubuntu/jammy/",
                                 "DriverName": "amdgpu-install_6.3.60303-1_all.deb"
                             },
                             {
@@ -106,7 +101,6 @@
                                     "Ubuntu 24.04" : ["6.8.*-azure"]
                                 },
                                 "MinimumDiskSpace" : "64 GB",
-                                "RepoLink" : "https://repo.radeon.com/amdgpu-install/6.3.3/ubuntu/noble/",
                                 "DriverName": "amdgpu-install_6.3.60303-1_all.deb"
                             }
                         ]

--- a/AmdGPU/AMD-GPU-Linux-Resources.json
+++ b/AmdGPU/AMD-GPU-Linux-Resources.json
@@ -62,8 +62,7 @@
                                 "MinKernelsSupportedForOSVersion":{
                                     "Ubuntu 22.04" : ["6.8.*-azure"]
                                 },
-                                "MinimumDiskSpace" : "64 GB",
-                                "DriverName": "amdgpu-install_6.4.60400-1_all.deb"
+                                "MinimumDiskSpace" : "64 GB"
                             },
                             {
                                 "SupportedOSVersions": [
@@ -72,8 +71,7 @@
                                 "MinKernelsSupportedForOSVersion":{
                                     "Ubuntu 24.04" : ["6.8.*-azure"]
                                 },
-                                "MinimumDiskSpace" : "64 GB",
-                                "DriverName": "amdgpu-install_6.4.60400-1_all.deb"
+                                "MinimumDiskSpace" : "64 GB"
                             }
                         ]
                     },
@@ -90,8 +88,7 @@
                                 "MinKernelsSupportedForOSVersion":{
                                     "Ubuntu 22.04" : ["6.8.*-azure"]
                                 },
-                                "MinimumDiskSpace" : "64 GB",
-                                "DriverName": "amdgpu-install_6.3.60303-1_all.deb"
+                                "MinimumDiskSpace" : "64 GB"
                             },
                             {
                                 "SupportedOSVersions": [
@@ -100,8 +97,7 @@
                                 "MinKernelsSupportedForOSVersion":{
                                     "Ubuntu 24.04" : ["6.8.*-azure"]
                                 },
-                                "MinimumDiskSpace" : "64 GB",
-                                "DriverName": "amdgpu-install_6.3.60303-1_all.deb"
+                                "MinimumDiskSpace" : "64 GB"
                             }
                         ]
                     }


### PR DESCRIPTION
This pull request updates the `AMD-GPU-Linux-Resources.json` file by removing all instances of the `repoLinks` property as requested. 

- Six `RepoLink` entries have been deleted.
- The JSON structure has been validated to ensure it remains valid and no `repoLink` variants are present. 

These changes help streamline the resource file by eliminating unnecessary links, improving clarity and maintainability.